### PR TITLE
Avoid dropping first word in session-less messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ app.post('/support', (req, res, next) => {
   const tomorrow = moment(today).add(1, 'days');
   const sentences = text ? text.split(' ') : [];
   let session = sentences[0] && (sentences[0].includes('https://') || sentences[0].includes('http://')) ? sentences[0] : null;
-  let issue = sentences.slice(1).join(' ');
+  let issue = session ? sentences.slice(1).join(' ') : sentences.join(' ');
   if(text === "cancel"){
     Ticket.findOne({
       by: user_name,


### PR DESCRIPTION
Students can ask for support with url and messages like this `/ta-support URL some freeform message`.
But if they don't provide a session url, the first word from the message is considered the session url, ignored (since it's not a url) but dropped from the message. You can test it like `/ta-support please help me` -- the word `please` won't be in the final message.

This PR fixes that :)
(also: we need tests)