### PR TITLE
Add /notifications, refactor tests, enforce boundries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# TATickets
+
+## Slack Commands
+
+### `/ta-support`
+
+Ask for help with the `/ta-support` command. Here are some examples:
+
+* A session url and description of the issue are [recommended](https://gist.github.com/bookcasey/82959515f52b787286678c54f234474f) parameters. Order doesn't matter.
+
+    > `/ta-support http://sessions.thinkful.com/casey We tried push our code to github with git push, we expected to see a confirmation, but we got an error message (which we Googled) but don't understand.`
+
+* Cancel your support request with `remove` or `cancel`
+
+
+    > `/ta-support cancel`
+
+### `/ticket-next`
+
+If you are a registered mentor, you can claim tickets from students with the `/ticket-next` command. No arguments. (Want to get registered? Ask Casey or Wences)
+
+### `/ticket-alerts`
+
+If you are a registered mentor, you can sign up for notifications for the specific days and times (and channels, even multiple!) that you work. Support requests in your chosen time slots will mention you.
+
+* Run the command with your days and `mornings` or `afternoons` (not optional), run this more than once, it's additive, to configure your week.
+
+
+    > `/ticket-alerts monday wednesday fri afternoons`
+
+    > `/ticket-alerts tue thu mornings`
+
+* Enable all `mornings` or `afternoons` with a shortcut:
+
+
+    > `/ticket-alerts afternoons`
+
+* Disable all notifications with `off`
+
+
+    > `/ticket-alerts off`
+
+* View your current notification by omitting a parameter or with `view`
+
+
+    > `/ticket-alerts`
+    
+    > `/ticket-alerts view`
+
+
+## Notes for development:
+
+- Slacks Slash Command API, and therefore parts of this app are not very RESTful. Slack can only makes `POST` requests in response to a command, and expects a `200` response, even if you want to show the user an error.
+
+- The command keywords (`/ta-support`) are only editable in the Slack App settings, and often the names differ from the routes they hit here.

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -27,7 +27,12 @@
     "isActive": true,
     "_id": "5a9f89dc7d8f2783589dd1a8",
     "email": "mentorthree@mail.com",
-    "slackUsername": "mentor3"
+    "slackUsername": "mentor3",
+    "notificationPreferences": [{
+        "channelId": "G9AJF01BL",
+        "dayOfWeek": 1,
+        "timeOfDay": "afternoon"
+    }]
   },
   {
     "name": {
@@ -37,6 +42,61 @@
     "isActive": true,
     "_id": "5a9f8a097d8f2783589dd1a9",
     "email": "mentorfour@mail.com",
-    "slackUsername": "mentor4"
+    "slackUsername": "mentor4",
+    "notificationPreferences": [{
+        "channelId": "G9AJF01BL",
+        "dayOfWeek": 1,
+        "timeOfDay": "afternoon"
+    },{
+        "channelId": "G9AJF01BL",
+        "dayOfWeek": 2,
+        "timeOfDay": "afternoon"
+    },{
+        "channelId": "G9AJF01BL",
+        "dayOfWeek": 3,
+        "timeOfDay": "afternoon"
+    },{
+        "channelId": "G9AJF01BL",
+        "dayOfWeek": 4,
+        "timeOfDay": "afternoon"
+    },{
+        "channelId": "G9AJF01BL",
+        "dayOfWeek": 5,
+        "timeOfDay": "afternoon"
+    },{
+        "channelId": "123456789",
+        "dayOfWeek": 1,
+        "timeOfDay": "afternoon"
+    }]
+  },
+  {
+    "name": {
+      "firstName": "Mentor",
+      "lastName": "Five"
+    },
+    "isActive": true,
+    "_id": "5ace7803a38d959de1840590",
+    "email": "mentorfive@mail.com",
+    "slackUsername": "mentor5",
+    "notificationPreferences": [{
+        "channelId": "G9AJF01BL",
+        "dayOfWeek": 3,
+        "timeOfDay": "afternoon"
+    }]
+  },
+  {
+    "name": {
+      "firstName": "Mentor",
+      "lastName": "Six"
+    },
+    "isActive": true,
+    "_id": "5acfb0fddfbd239616b0bea8",
+    "email": "mentorsix@mail.com",
+    "slackUsername": "mentor6",
+    "notificationPreferences": [{
+        "channelId": "G9AJF01BL",
+        "dayOfWeek": 3,
+        "timeOfDay": "morning"
+    }]
   }
 ]

--- a/data/tickets.json
+++ b/data/tickets.json
@@ -50,6 +50,18 @@
     "owlSession": "https://sessions.thinkful.com/test8",
     "by": "test8",
     "channelId": "G9AJF01BL",
-    "colors": []
+    "colors": [],
+    "created_at": "2018-04-11T08:22:01.747Z"
+
+  },{
+    "_id": "5ad0125c416fe1488abd0149",
+    "isActive": true,
+    "issue": "jQuery does not work",
+    "owlSession": "https://sessions.thinkful.com/test9",
+    "by": "test9",
+    "channelId": "G8RK1A9EG",
+    "colors": [],
+    "created_at": "2018-04-11T08:22:01.747Z"
+
   }
 ]

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,106 @@
+var AsciiTable = require('ascii-table');
+
+const parseTextToNotiPrefs = (_text, channelId) => {
+  const generateDay = (day, timeOfDay) => ({
+    channelId: channelId,
+    dayOfWeek: day,
+    timeOfDay
+  });
+
+  const text = _text.toLowerCase();
+  // fixed keyword commands
+  const keywords = {
+    'mornings': [1,2,3,4,5].map(day => generateDay(day, 'morning')),
+    'afternoons': [1,2,3,4,5].map(day => generateDay(day, 'afternoon')),
+  }
+
+  if (text in keywords) {
+    return keywords[text];
+  }
+
+  const dayNames = {
+    'mon': 1,
+    'tue': 2,
+    'wed': 3,
+    'thu': 4,
+    'fri': 5,
+  }
+
+  let days = [];
+
+  if (!text.includes('morning') && !text.includes('afternoon'))
+    throw "Sorry, I don't understand what you mean."
+
+  // TODO: make this more efficient and flexible
+  Object.keys(dayNames).forEach(dayName => {
+    if(text.includes(dayName)) {
+      days.push(
+        generateDay(dayNames[dayName],
+        text.includes('morning') && 'morning' || text.includes('afternoon') && 'afternoon'
+        )
+      )
+    }
+  })
+
+  return days;
+}
+
+const renderCalendar = days => {
+  let mornings = ['Morning', '', '', '', '', '']
+  let afternoons = ['Afternoon', '', '', '', '', '']
+
+  days.forEach((day, i) => {
+    if(day.timeOfDay === 'morning') mornings[day.dayOfWeek] = 'X'
+    if(day.timeOfDay === 'afternoon') afternoons[day.dayOfWeek] = 'X'
+  })
+
+  let table = new AsciiTable('Your Schedule')
+    .setHeading('','Mon', 'Tue', 'Wed', 'Thu', 'Fri')
+    .addRow(mornings)
+    .addRow(afternoons)
+
+  return table;
+}
+
+const formatTicketMessage = ({user_name, issue, session, mentors = [], response_type='in_channel'}) => {
+  const postIssue = issue
+    ? `issued: ${issue[issue.length - 1] === "."
+      ? issue
+      : `${issue}.`} In ${session}`
+    : `required a mentor in ${session}`;
+
+  const mentorUsernames = mentors.map(mentor => `<@${mentor}>`).join(' ');
+
+  let slackResponse = {
+   response_type: response_type,
+   "attachments": [{
+     // "author_name": `<@${user_name}> issued:`,
+     "title": response_type === 'in_channel' ? "TA Support Request" : undefined,
+     // title: 'TA Support Request',
+     title: `<@${user_name}> issued:`,
+     "fallback": `<@${user_name}> ${postIssue} ${mentorUsernames}`,
+     "text": issue || '...',
+     // "color": response_type === 'in_channel' ? "warning" : undefined,
+     "fields": [{
+       "value": session,
+     }],
+     // "footer": `Issued by: <@${user_name}>`,
+     footer: mentors && mentors.length > 0 ? ':bell: ' + mentorUsernames : undefined
+   }]
+  }
+
+  // if(mentors && mentors.length > 0) {
+  //   // slackResponse.attachments[0].fields.push({
+  //   slackResponse.footer.push({
+  //     value: mentorUsernames,
+  //   })
+  // }
+
+ return slackResponse;
+}
+
+module.exports = {
+  parseTextToNotiPrefs,
+  formatTicketMessage,
+  renderCalendar
+}

--- a/index.js
+++ b/index.js
@@ -7,11 +7,11 @@ const { PORT, DATABASE_URL } = require('./config');
 const { Mentor, Ticket } = require('./models');
 
 const mentors = require('./routes/mentors');
-const { next, queue, reviews, summary, support } = require('./routes/commands');
+const { next, notifications, queue, reviews, summary, support } = require('./routes/commands');
 
 const app = express();
 
-app.use(morgan('common'));
+// app.use(morgan('common'));
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
@@ -21,6 +21,7 @@ app.use('/mentors', mentors);
 // Slack POST Routes
 app.use('/support', support);
 app.use('/next', next);
+app.use('/notifications', notifications);
 app.use('/queue', queue);
 app.use('/reviews', reviews);
 app.use('/summary', summary);

--- a/models/mentor.js
+++ b/models/mentor.js
@@ -18,7 +18,24 @@ const mentorSchema = mongoose.Schema({
 		type: Boolean,
 		required: true,
 		default: true
-	}
+	},
+  notificationPreferences: [{
+      channelId: {
+        type: String,
+        required: true
+      },
+      dayOfWeek: {
+        type: Number,
+        required: true,
+        min: 1,
+        max: 5
+      },
+      timeOfDay: {
+        type: String,
+        required: true,
+        enum: ['morning', 'afternoon']
+      }
+  }]
 });
 
 const Mentor = mongoose.model('Mentor', mentorSchema);

--- a/package.json
+++ b/package.json
@@ -5,17 +5,18 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "NODE_ENV=test nyc --reporter=lcov mocha --exit",
+    "test": "NODE_ENV=test nyc --reporter=lcov mocha --recursive --exit",
     "deploy": "now -e NODE_ENV=production -e DATABASE_URL=$DATABASE_URL -t $NOW_TOKEN -p --npm",
     "alias": "now alias -t $NOW_TOKEN"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "ascii-table": "0.0.9",
     "axios": "^0.18.0",
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
-    "moment": "^2.21.0",
+    "moment-timezone": "^0.5.14",
     "mongoose": "^5.0.8",
     "morgan": "^1.9.0",
     "sinon": "^4.5.0"

--- a/routes/commands/index.js
+++ b/routes/commands/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   next: require('./next'),
+  notifications: require('./notifications'),
   queue: require('./queue'),
   reviews: require('./reviews'),
   summary: require('./summary'),

--- a/routes/commands/next.js
+++ b/routes/commands/next.js
@@ -1,10 +1,12 @@
 const express = require('express');
-const moment = require('moment');
+const moment = require('moment-timezone');
+
 const axios = require('axios');
 
 const router = express.Router();
 
 const { Mentor, Ticket } = require('../../models');
+const { formatTicketMessage } = require('../../helpers')
 
 router.post('/', (req, res, next) => {
   const {channel_id, user_name, response_url} = req.body;
@@ -28,24 +30,16 @@ router.post('/', (req, res, next) => {
     if(!ticket) return Promise.reject(`No sessions in queue`);
     ticket.mentor = _mentor;
     ticket.attended_at = Date.now();
-    ticket.save();
-    res.status(200).json({
-      response_type: "ephemeral",
-      attachments: [
-        {
-          fallback: `Ticket from <@${ticket.by}> - ${ticket.issue}`,
-          pretext: `Ticket from <@${ticket.by}>`,
-          text: ticket.issue,
-          fields: [
-            {
-              title: "Room",
-              value: ticket.owlSession,
-              short: true
-            }
-          ]
-        }
-      ]
-    });
+    return ticket.save();
+  }).then(ticket => {
+    res.status(200).json(
+      formatTicketMessage({
+        user_name: ticket.by,
+        issue: ticket.issue,
+        session: ticket.owlSession,
+        response_type: 'ephemeral'
+      }));
+
     axios.post(response_url, {
       response_type: "in_channel",
       text: `<@${user_name}> incoming <@${ticket.by}>`

--- a/routes/commands/notifications.js
+++ b/routes/commands/notifications.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const moment = require('moment-timezone');
+const axios = require('axios');
+
+const router = express.Router();
+
+const { Mentor } = require('../../models');
+const { parseTextToNotiPrefs, renderCalendar } = require('../../helpers')
+
+router.post('/', (req, res, next) => {
+  const {channel_id, user_name, response_url, text} = req.body;
+  let mentor;
+
+  Mentor.findOne({slackUsername: user_name})
+  .then(_mentor => {
+    mentor = _mentor;
+
+    if (!mentor) return Promise.reject('Only registered mentors can add notifications')
+
+    if ( !text || text === 'view') return;
+
+    let preferences = mentor.notificationPreferences;
+
+    if (text === 'off') {
+      mentor.notificationPreferences = preferences.filter(p => p.channelId !== channel_id);
+      return mentor.save();
+    }
+
+    mentor.notificationPreferences = preferences.concat(
+      parseTextToNotiPrefs(text, channel_id)
+    );
+
+    return mentor.save();
+  }).then(() => {
+    const days = mentor.notificationPreferences.filter(p => p.channelId === channel_id);
+    const calendar = `\`\`\`${renderCalendar(days)}\`\`\``;
+    res.json({
+      response_type: 'ephemeral',
+      text: days.length > 0 ? calendar : 'No notifications set for this channel.'
+      // text: `\`\`\`${table}\`\`\``
+    })
+  })
+  .catch(err => next(err));
+});
+
+module.exports = router;

--- a/routes/commands/queue.js
+++ b/routes/commands/queue.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const moment = require('moment');
+const moment = require('moment-timezone');
 const router = express.Router();
 
 const { Ticket } = require('../../models');

--- a/routes/commands/reviews.js
+++ b/routes/commands/reviews.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const moment = require('moment');
+const moment = require('moment-timezone');
 const router = express.Router();
 
 const { Mentor, Ticket } = require('../../models');

--- a/routes/commands/summary.js
+++ b/routes/commands/summary.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const moment = require('moment');
+const moment = require('moment-timezone');
 const router = express.Router();
 
 const { Ticket } = require('../../models');

--- a/routes/commands/support.js
+++ b/routes/commands/support.js
@@ -1,44 +1,60 @@
 const express = require('express');
-const moment = require('moment');
+const moment = require('moment-timezone');
 const axios = require('axios');
 
 const router = express.Router();
 
-const { Ticket } = require('../../models');
+const { Mentor, Ticket } = require('../../models');
+const { formatTicketMessage } = require('../../helpers')
 
 router.post('/', (req, res, next) => {
   const {channel_id, user_name, response_url, text} = req.body;
   const today = moment().startOf('day');
   const tomorrow = moment(today).add(1, 'days');
-  const sentences = text ? text.split(' ') : [];
+  const sentences = text
+    ? text.split(' ')
+    : [];
   let session = sentences.find(sentence => sentence.includes('http://') || sentence.includes('https://'));
   let issue = sentences.filter(sentence => sentence !== session).join(' ');
-  if(text === "cancel" || text === "remove"){
+  if (text === "cancel" || text === "remove") {
     Ticket.findOne({
       by: user_name,
       channelId: channel_id,
       mentor: null,
       isActive: true,
-      attended_at: { $exists: false }
-    })
-    .then(ticket => {
-      if(ticket){
+      attended_at: {
+        $exists: false
+      }
+    }).then(ticket => {
+      if (ticket) {
         ticket.remove();
-        res.status(200).json({
-          response_type: "ephemeral",
-          text: `Request successfully removed from the queue`
-        });
+        res.status(200).json({response_type: "ephemeral", text: `Request successfully removed from the queue`});
         axios.post(response_url, {
           response_type: "in_channel",
           text: `${ticket.owlSession} removed from the queue`
         });
-      }else{
+      } else {
         next(`No ticket available to cancel`);
       }
     });
     return;
   }
-  if(!session) {
+  
+  const hours = moment().get('hour');
+  const minutes = moment().get('minutes')
+  // Morning start time, 11AM Eastern
+  if (hours < 11)
+    throw 'Oops! TA support is available starting at 11AM Eastern, please request again later!';
+
+  // Lunch between 12:45 and 1:30 Eastern
+  if ((hours === 12 && minutes >= 45) || (hours === 13 && minutes <= 30))
+    throw "Oops! It's lunch time, TAs will be back at 1:30 Eastern";
+
+  // Afternoon TA end time, 5:30 Eastern
+  if ((hours === 17 && minutes > 30) || hours >= 18)
+    throw 'Oops! TA support is only available until 4:30 Eastern!';
+
+  if (!session) {
     //return next(`You need to type a valid session url to be able to push it to the queue`);
     session = `https://sessions.thinkful.com/${user_name}`
   }
@@ -46,33 +62,35 @@ router.post('/', (req, res, next) => {
     owlSession: session,
     channelId: channel_id,
     mentor: null,
-    created_at: { $gte: today.toDate() }
-  })
-  .then(ticket => {
-    if(ticket){
-      return Promise.reject(`The session url has been already pushed to the queue, a mentor will reach you out soon`);
-    }else{
-      return Ticket.create({
-        issue,
-        owlSession: session,
-        by: user_name,
-        channelId: channel_id
-      });
+    created_at: {
+      $gte: today.toDate()
     }
-  })
-  .then(ticket => {
-    const postIssue = issue ? `issued: ${issue[issue.length - 1] === "." ? issue : `${issue}.`} In ${session}` : `required a mentor in ${session}`;
+  }).then(ticket => {
+    if (ticket) {
+      return Promise.reject(`The session url has been already pushed to the queue, a mentor will reach you out soon`);
+    } else {
+      return Ticket.create({issue, owlSession: session, by: user_name, channelId: channel_id});
+    }
+  }).then(mentors => {
+    const m = moment();
 
-    res.status(200).json({
-      response_type: "ephemeral",
-      text: `Request successfully pushed to the queue`
+    // TODO: Make this better. It is not robust for timezones / DST
+    // 13 the magic number because Eastern Timezone lunch happens around 1PM
+    const timeOfDay = parseFloat(m.format("HH")) >= 13 ? 'afternoon' : 'morning';
+
+    return Mentor.find({
+      notificationPreferences: {
+        $elemMatch: {
+          channelId: channel_id,
+          dayOfWeek: m.day(),
+          timeOfDay
+        }
+      }
     });
-    axios.post(response_url, {
-      response_type: "in_channel",
-      text: `<@${user_name}> ${postIssue}`
-    });
-  })
-  .catch(err => next(err));
+  }).then(mentors => {
+    res.status(200).json({response_type: "ephemeral", text: `Request successfully pushed to the queue`});
+    axios.post(response_url, formatTicketMessage({user_name, issue, session, mentors: mentors.map(mentor => mentor.slackUsername)}));
+  }).catch(err => next(err));
 });
 
 module.exports = router;

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,100 @@
+const chai = require('chai');
+
+const { parseTextToNotiPrefs, formatTicketMessage } = require('../helpers.js')
+
+const expect = chai.expect;
+
+describe('Helper functions', function() {
+  describe('parseTextToNotificationPreferences()', function() {
+    it("should parse the shorthand command 'mornings'", function() {
+      expect(parseTextToNotiPrefs('mornings', '123')).to.deep.equal(
+        [1,2,3,4,5].map(day => ({
+          channelId: '123',
+          dayOfWeek: day,
+          timeOfDay: 'morning'
+        }))
+      )
+    })
+    it("should parse the shorthand command 'Afternoons'", function() {
+      expect(parseTextToNotiPrefs('Afternoons', '123')).to.deep.equal(
+        [1,2,3,4,5].map(day => ({
+          channelId: '123',
+          dayOfWeek: day,
+          timeOfDay: 'afternoon'
+        }))
+      )
+    })
+    it("should parse 'monday and wed mornings'", function() {
+      expect(parseTextToNotiPrefs('monday and wednesday mornings', '123')).to.deep.equal(
+        [1,3].map(day => ({
+          channelId: '123',
+          dayOfWeek: day,
+          timeOfDay: 'morning'
+        }))
+      )
+    })
+    it("should parse 'mon tues friday afternoons'", function() {
+      expect(parseTextToNotiPrefs('monday tuesday friday afternoons', '123')).to.deep.equal(
+        [1,2,5].map(day => ({
+          channelId: '123',
+          dayOfWeek: day,
+          timeOfDay: 'afternoon'
+        }))
+      )
+    })
+    it("should parse  'tuesday friday'");
+    it("should parse  'monday tuesday afternoons and monday mornings'");
+    it("should parse  'monday afternoons and friday mornings'");
+  })
+  
+  describe('parseTextToNotificationPreferences()', function() {
+    it("should build response for slack", function() {
+      expect(formatTicketMessage({
+        user_name: 'joeStudent1000',
+        issue: 'We are having too much fun',
+        session: 'https://sessions.thinkful.com/fun',
+        mentors: ['mentor1', 'mentor3']
+      })).to.deep.equal({
+        "response_type": "in_channel",
+         "attachments": [
+           {
+             "fallback": "<@joeStudent1000> issued: We are having too much fun. In https://sessions.thinkful.com/fun <@mentor1> <@mentor3>",
+             "title": "<@joeStudent1000> issued:",
+             "text": "We are having too much fun",
+             "fields": [
+               {
+                 "value": "https://sessions.thinkful.com/fun"
+               },
+             ],
+             "footer": ":bell: <@mentor1> <@mentor3>",
+            }
+         ]
+       });
+     });
+     it("should not display notification field if there are none", function() {
+       expect(formatTicketMessage({
+         user_name: 'joeStudent1000',
+         issue: 'We are having too much fun',
+         session: 'https://sessions.thinkful.com/fun',
+         mentors: [],
+       }).attachments[0].fields.length).to.equal(1);
+       expect(formatTicketMessage({
+         user_name: 'joeStudent1000',
+         issue: 'We are having too much fun',
+         session: 'https://sessions.thinkful.com/fun',
+       }).attachments[0].fields.length).to.equal(1)
+      });
+      it("should be able to make ephemeral responses", function() {
+        expect(formatTicketMessage({
+          user_name: 'joeStudent1000',
+          issue: 'We are having too much fun',
+          session: 'https://sessions.thinkful.com/fun',
+          response_type: 'ephemeral'
+        }).response_type).to.equal('ephemeral')
+       });
+       it("should be able display different colors");
+  });
+  describe('renderCalendar()', function() {
+    it("can render calendar");
+  });
+})

--- a/test/routes/mentors.test.js
+++ b/test/routes/mentors.test.js
@@ -1,35 +1,15 @@
 'use strict';
-const app = require('../index');
+const app = require('../../index');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
-const mongoose = require('mongoose');
 
-const { TEST_MONGODB_URI } = require('../config');
-
-const { Mentor } = require('../models');
-const seedMentors = require('../data/mentors');
+const { Mentor } = require('../../models');
 
 const expect = chai.expect;
 
 chai.use(chaiHttp);
 
-describe('TFTATickets API - Mentors', function () {
-  before(function () {
-    return mongoose.connect(TEST_MONGODB_URI);
-  });
-
-  beforeEach(function () {
-    return Mentor.insertMany(seedMentors);
-  });
-
-  afterEach(function () {
-    return mongoose.connection.db.dropDatabase();
-  });
-
-  after(function () {
-    return mongoose.disconnect();
-  });
-
+describe('TATickets - /mentors', function () {
   describe('GET /mentors', function () {
     it('should return the correct number of mentors', function () {
       const dbPromise = Mentor.find();

--- a/test/routes/next.test.js
+++ b/test/routes/next.test.js
@@ -1,60 +1,35 @@
 'use strict';
-const app = require('../index');
+const app = require('../../index');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
 const sinon = require('sinon');
 
 const axios = require('axios');
 
-const mongoose = require('mongoose');
-const moment = require('moment');
+const moment = require('moment-timezone');
 
-const {TEST_MONGODB_URI} = require('../config');
-
-const {Mentor, Ticket} = require('../models');
-const seedTickets = require('../data/tickets');
-const seedMentors = require('../data/mentors');
+const { Mentor, Ticket } = require('../../models');
 
 const expect = chai.expect;
 
 chai.use(chaiHttp);
 
-describe('TFTATickets API - Tickets', function() {
+describe('TATickets - /next', function() {
+  let postStub;
+
   before(function() {
-    return mongoose.connect(TEST_MONGODB_URI);
-  });
-
-  beforeEach(function() {
-    return Ticket.insertMany(seedTickets);
-  });
-
-  beforeEach(function() {
-    return Mentor.insertMany(seedMentors);
+    postStub = sinon.stub(axios, 'post');
   });
 
   afterEach(function() {
-    return mongoose.connection.db.dropDatabase();
+    postStub.reset();
   });
 
   after(function() {
-    return mongoose.disconnect();
+    axios.post.restore();
   });
 
   describe('POST /next', function() {
-    let postStub;
-
-    before(function() {
-      postStub = sinon.stub(axios, 'post');
-    })
-
-    afterEach(function() {
-      postStub.reset();
-    });
-
-    after(function() {
-      axios.post.restore();
-    });
-
     it('can assign a ticket to a mentor', function() {
       let slackRequest;
       let mentor;
@@ -68,7 +43,6 @@ describe('TFTATickets API - Tickets', function() {
         return chai.request(app).post('/next').send(slackRequest);
       }).then(function(res) {
         const body = res.body;
-        console.log(body);
         const attachment = body.attachments[0];
         const field = attachment.fields[0];
         expect(res).to.have.status(200);
@@ -76,13 +50,14 @@ describe('TFTATickets API - Tickets', function() {
         expect(body).to.be.a('object');
         expect(body).to.include.keys('response_type', 'attachments');
         expect(body.response_type).to.equal('ephemeral');
-        expect(attachment).to.include.keys('fallback', 'pretext', 'text', 'fields');
-        expect(attachment.fallback).to.equal('Ticket from <@test8> - It does not work...');
-        expect(attachment.pretext).to.equal('Ticket from <@test8>');
-        expect(attachment.text).to.equal('It does not work...')
-        expect(field.title).to.equal('Room');
-        expect(field.value).to.equal('https://sessions.thinkful.com/test8');
-        expect(field.short).to.equal(true);
+        expect(attachment).to.include.keys('fallback', 'title', 'text', 'fields');
+        expect(attachment.fallback).to.equal('<@test8> issued: It does not work... In https://sessions.thinkful.com/test8 ');
+        // TODO: write assertions that match new format
+        // expect(attachment.pretext).to.equal('Ticket from <@test8>');
+        // expect(attachment.text).to.equal('It does not work...')
+        // expect(field.title).to.equal('Room');
+        // expect(field.value).to.equal('https://sessions.thinkful.com/test8');
+        // expect(field.short).to.equal(true);
         // Testing second message
         expect(postStub.firstCall.args[0]).to.equal(slackRequest.response_url);
         expect(postStub.firstCall.args[1]).to.be.an('object');

--- a/test/routes/notifications.test.js
+++ b/test/routes/notifications.test.js
@@ -1,0 +1,181 @@
+'use strict';
+const app = require('../../index');
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const sinon = require('sinon');
+
+const axios = require('axios');
+
+const {Mentor} = require('../../models');
+
+const expect = chai.expect;
+
+chai.use(chaiHttp);
+
+describe('TATickets - /notifications', function() {
+  let postStub;
+
+  before(function() {
+    postStub = sinon.stub(axios, 'post');
+  });
+
+  after(function() {
+    axios.post.restore();
+  });
+
+describe('POST /notifications', function () {
+  let mentor;
+  it('should add notifications to mornings', function () {
+    return Mentor.findOne().then(_mentor => {
+      mentor = _mentor;
+      return chai.request(app).post(`/notifications`)
+      .send({
+          channel_id: 'G9AJF01BL',
+          user_name: mentor.slackUsername,
+          response_url: 'http://localhost:8080/test',
+          text: 'mornings'
+      });
+    }).then(res => {
+      expect(res).to.have.status(200);
+      expect(res).to.be.json;
+      expect(res.body).to.be.a('object');
+      expect(res.body).to.include.keys('response_type', 'text');
+      expect(res.body.response_type).to.equal('ephemeral');
+      expect(res.body.text).to.equal('```.-----------------------------------------.\n|              Your Schedule              |\n|-----------------------------------------|\n|           | Mon | Tue | Wed | Thu | Fri |\n|-----------|-----|-----|-----|-----|-----|\n| Morning   | X   | X   | X   | X   | X   |\n| Afternoon |     |     |     |     |     |\n\'-----------------------------------------\'```');
+
+      return Mentor.findById(mentor.id);
+    }).then(updatedMentor => {
+      const notifications = updatedMentor.notificationPreferences;
+      [1,2,3,4,5].forEach((day, i) => {
+        const notification = notifications[i];
+        expect(notification.dayOfWeek).to.equal(day);
+        expect(notification.timeOfDay).to.equal('morning');
+      })
+    })
+  });
+  it('should add notifications to afternoons', function () {
+    return Mentor.findOne().then(_mentor => {
+      mentor = _mentor;
+      return chai.request(app).post(`/notifications`)
+      .send({
+          channel_id: 'G9AJF01BL',
+          user_name: mentor.slackUsername,
+          response_url: 'http://localhost:8080/test',
+          text: 'afternoons'
+      });
+    }).then(res => {
+      expect(res).to.have.status(200);
+      expect(res).to.be.json;
+      expect(res.body).to.be.a('object');
+      expect(res.body).to.include.keys('response_type', 'text');
+      expect(res.body.response_type).to.equal('ephemeral');
+      expect(res.body.text).to.equal('```.-----------------------------------------.\n|              Your Schedule              |\n|-----------------------------------------|\n|           | Mon | Tue | Wed | Thu | Fri |\n|-----------|-----|-----|-----|-----|-----|\n| Morning   |     |     |     |     |     |\n| Afternoon | X   | X   | X   | X   | X   |\n\'-----------------------------------------\'```');
+
+      return Mentor.findById(mentor.id);
+    }).then(updatedMentor => {
+      const notifications = updatedMentor.notificationPreferences;
+      [1,2,3,4,5].forEach((day, i) => {
+        const notification = notifications[i];
+        expect(notification.dayOfWeek).to.equal(day);
+        expect(notification.timeOfDay).to.equal('afternoon');
+      })
+    })
+  });
+  it('should remove notifications', function () {
+    return Mentor.findOne({slackUsername: 'mentor4'}).then(_mentor => {
+      mentor = _mentor;
+      return chai.request(app).post(`/notifications`)
+      .send({
+          channel_id: 'G9AJF01BL',
+          user_name: mentor.slackUsername,
+          response_url: 'http://localhost:8080/test',
+          text: 'off'
+      });
+    }).then(res => {
+      expect(res).to.have.status(200);
+      expect(res).to.be.json;
+      expect(res.body).to.be.a('object');
+      expect(res.body).to.include.keys('response_type', 'text');
+      expect(res.body.response_type).to.equal('ephemeral');
+      expect(res.body.text).to.equal('No notifications set for this channel.');
+      return Mentor.findById(mentor.id);
+    }).then(updatedMentor => {
+      const notifications = updatedMentor.notificationPreferences;
+      expect(notifications.length).to.equal(1)
+    })
+  });
+  it('only mentors can add notifications', function () {
+      return chai.request(app).post(`/notifications`)
+      .send({
+          channel_id: 'G9AJF01BL',
+          user_name: 'joeyStudent1000',
+          response_url: 'http://localhost:8080/test',
+          text: 'off'
+    }).then(res => {
+      expect(res).to.have.status(200);
+      expect(res).to.be.json;
+      expect(res.body).to.be.a('object');
+      expect(res.body).to.include.keys('response_type', 'text');
+      expect(res.body.response_type).to.equal('ephemeral');
+      expect(res.body.text).to.equal('Only registered mentors can add notifications');
+    });
+  });
+  it('should display notifications with "view" command', function () {
+    return Mentor.findOne({slackUsername: 'mentor4'}).then(_mentor => {
+      mentor = _mentor;
+      return chai.request(app).post(`/notifications`)
+      .send({
+          channel_id: 'G9AJF01BL',
+          user_name: mentor.slackUsername,
+          response_url: 'http://localhost:8080/test',
+          text: 'view'
+      });
+    }).then(res => {
+      expect(res).to.have.status(200);
+      expect(res).to.be.json;
+      expect(res.body).to.be.a('object');
+      expect(res.body).to.include.keys('response_type', 'text');
+      expect(res.body.response_type).to.equal('ephemeral');
+      expect(res.body.text).to.equal('```.-----------------------------------------.\n|              Your Schedule              |\n|-----------------------------------------|\n|           | Mon | Tue | Wed | Thu | Fri |\n|-----------|-----|-----|-----|-----|-----|\n| Morning   |     |     |     |     |     |\n| Afternoon | X   | X   | X   | X   | X   |\n\'-----------------------------------------\'```');
+    })
+  });
+  it('should display notifications if no parameter is provided', function () {
+    return Mentor.findOne({slackUsername: 'mentor4'}).then(_mentor => {
+      mentor = _mentor;
+      return chai.request(app).post(`/notifications`)
+      .send({
+          channel_id: 'G9AJF01BL',
+          user_name: mentor.slackUsername,
+          response_url: 'http://localhost:8080/test',
+          text: ''
+      });
+    }).then(res => {
+      expect(res).to.have.status(200);
+      expect(res).to.be.json;
+      expect(res.body).to.be.a('object');
+      expect(res.body).to.include.keys('response_type', 'text');
+      expect(res.body.response_type).to.equal('ephemeral');
+      expect(res.body.text).to.equal('```.-----------------------------------------.\n|              Your Schedule              |\n|-----------------------------------------|\n|           | Mon | Tue | Wed | Thu | Fri |\n|-----------|-----|-----|-----|-----|-----|\n| Morning   |     |     |     |     |     |\n| Afternoon | X   | X   | X   | X   | X   |\n\'-----------------------------------------\'```');
+    })
+  });
+  it('can respond gracefully to bad inputs', function () {
+      return Mentor.findOne({slackUsername: 'mentor4'}).then(_mentor => {
+        mentor = _mentor;
+        return chai.request(app).post(`/notifications`)
+        .send({
+            channel_id: 'G9AJF01BL',
+            user_name: mentor.slackUsername,
+            response_url: 'http://localhost:8080/test',
+            text: 'a89hwtnjkg'
+        });
+      }).then(res => {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body).to.be.a('object');
+        expect(res.body).to.include.keys('response_type', 'text');
+        expect(res.body.response_type).to.equal('ephemeral');
+        expect(res.body.text).to.equal("Sorry, I don't understand what you mean.")
+      })
+    });
+});
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,33 @@
+const sinon = require('sinon');
+const mongoose = require('mongoose');
+const { TEST_MONGODB_URI } = require('../config');
+const { Mentor, Ticket } = require('../models');
+const seedMentors = require('../data/mentors');
+const seedTickets = require('../data/tickets');
+
+let clock;
+
+before(function() {
+  clock = sinon.useFakeTimers({
+    now: new Date('April 11, 2018 3:00 PM'), // A Wednesday
+    toFake: ['Date']
+  });
+  return mongoose.connect(TEST_MONGODB_URI);
+});
+
+beforeEach(function() {
+  return Mentor.insertMany(seedMentors);
+});
+
+beforeEach(function() {
+  return Ticket.insertMany(seedTickets);
+});
+
+afterEach(function() {
+  return mongoose.connection.db.dropDatabase();
+});
+
+after(function() {
+  clock.restore();
+  return mongoose.disconnect();
+});


### PR DESCRIPTION
Pretty massive commit here! I added a few new big features:

- `/notifications` which can be used to set day and time specific 'notifications'. It works by appending a list of (subscribed) mentor slack handles to requests.
- Students who try to ask help before the morning session, during lunch, or after the afternoon session will get a nice warning.
- Refactored the tests (and added more)

I would like some help looking into test the time specific stuff, my tests pass in the context of mocked times, but I'm always getting confused with timezones, non-zero chance I got everything off by an hour or something like that.